### PR TITLE
Adding the cloud-solution prefix to the module name

### DIFF
--- a/reference-architectures/backstage/backstage-quickstart/initialize/main.tf
+++ b/reference-architectures/backstage/backstage-quickstart/initialize/main.tf
@@ -20,7 +20,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "platform-engineering-backstage-quickstart-deploy-v1"
+    module_name = "cloud-solutions/platform-engineering-backstage-quickstart-deploy-v1"
   }
 
 }

--- a/reference-architectures/backstage/backstage-quickstart/main.tf
+++ b/reference-architectures/backstage/backstage-quickstart/main.tf
@@ -20,7 +20,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "platform-engineering-backstage-quickstart-deploy-v1"
+    module_name = "cloud-solutions/platform-engineering-backstage-quickstart-deploy-v1"
   }
 
 }


### PR DESCRIPTION
Adds the cloud-solutions prefix to the module name in the Terraform metadata for the backstage quick start.