### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/docs/reference-architectures/backstage/backstage-quickstart/index.html
+++ b/docs/reference-architectures/backstage/backstage-quickstart/index.html
@@ -1,3 +1,4 @@
+
 <!doctype html>
 <html lang="en" class="no-js">
   <head>
@@ -2094,7 +2095,7 @@ permissions.</p>
 </span><span id="__span-29-3"><a id="__codelineno-29-3" name="__codelineno-29-3" href="#__codelineno-29-3"></a>xargs<span class="k">)</span><span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-4"><a id="__codelineno-29-4" name="__codelineno-29-4" href="#__codelineno-29-4"></a>cp<span class="w"> </span>backend.tf.local<span class="w"> </span>backend.tf<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-5"><a id="__codelineno-29-5" name="__codelineno-29-5" href="#__codelineno-29-5"></a>terraform<span class="w"> </span>init<span class="w"> </span>-force-copy<span class="w"> </span>-lock<span class="o">=</span><span class="nb">false</span><span class="w"> </span>-migrate-state<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
-</span><span id="__span-29-6"><a id="__codelineno-29-6" name="__codelineno-29-6" href="#__codelineno-29-6"></a>gcloud<span class="w"> </span>storage<span class="w"> </span>rm<span class="w"> </span>--recursive<span class="w"> </span>--continue-on-error<span class="w"> </span>gs://<span class="si">${</span><span class="nv">TERRAFORM_BUCKET_NAME</span><span class="si">}</span>/*<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
+</span><span id="__span-29-6"><a id="__codelineno-29-6" name="__codelineno-29-6" href="#__codelineno-29-6"></a>gsutil<span class="w"> </span>-m<span class="w"> </span>rm<span class="w"> </span>-rf<span class="w"> </span>gs://<span class="si">${</span><span class="nv">TERRAFORM_BUCKET_NAME</span><span class="si">}</span>/*<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-7"><a id="__codelineno-29-7" name="__codelineno-29-7" href="#__codelineno-29-7"></a>terraform<span class="w"> </span>init<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-8"><a id="__codelineno-29-8" name="__codelineno-29-8" href="#__codelineno-29-8"></a>terraform<span class="w"> </span>destroy<span class="w"> </span>-auto-approve<span class="w">  </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-9"><a id="__codelineno-29-9" name="__codelineno-29-9" href="#__codelineno-29-9"></a>rm<span class="w"> </span>-rf<span class="w"> </span>.terraform<span class="w"> </span>.terraform.lock.hcl<span class="w"> </span>state/

--- a/docs/reference-architectures/backstage/backstage-quickstart/index.html
+++ b/docs/reference-architectures/backstage/backstage-quickstart/index.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html lang="en" class="no-js">
   <head>
@@ -2095,7 +2094,7 @@ permissions.</p>
 </span><span id="__span-29-3"><a id="__codelineno-29-3" name="__codelineno-29-3" href="#__codelineno-29-3"></a>xargs<span class="k">)</span><span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-4"><a id="__codelineno-29-4" name="__codelineno-29-4" href="#__codelineno-29-4"></a>cp<span class="w"> </span>backend.tf.local<span class="w"> </span>backend.tf<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-5"><a id="__codelineno-29-5" name="__codelineno-29-5" href="#__codelineno-29-5"></a>terraform<span class="w"> </span>init<span class="w"> </span>-force-copy<span class="w"> </span>-lock<span class="o">=</span><span class="nb">false</span><span class="w"> </span>-migrate-state<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
-</span><span id="__span-29-6"><a id="__codelineno-29-6" name="__codelineno-29-6" href="#__codelineno-29-6"></a>gsutil<span class="w"> </span>-m<span class="w"> </span>rm<span class="w"> </span>-rf<span class="w"> </span>gs://<span class="si">${</span><span class="nv">TERRAFORM_BUCKET_NAME</span><span class="si">}</span>/*<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
+</span><span id="__span-29-6"><a id="__codelineno-29-6" name="__codelineno-29-6" href="#__codelineno-29-6"></a>gcloud<span class="w"> </span>storage<span class="w"> </span>rm<span class="w"> </span>--recursive<span class="w"> </span>--continue-on-error<span class="w"> </span>gs://<span class="si">${</span><span class="nv">TERRAFORM_BUCKET_NAME</span><span class="si">}</span>/*<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-7"><a id="__codelineno-29-7" name="__codelineno-29-7" href="#__codelineno-29-7"></a>terraform<span class="w"> </span>init<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-8"><a id="__codelineno-29-8" name="__codelineno-29-8" href="#__codelineno-29-8"></a>terraform<span class="w"> </span>destroy<span class="w"> </span>-auto-approve<span class="w">  </span><span class="o">&amp;&amp;</span><span class="w"> </span><span class="se">\</span>
 </span><span id="__span-29-9"><a id="__codelineno-29-9" name="__codelineno-29-9" href="#__codelineno-29-9"></a>rm<span class="w"> </span>-rf<span class="w"> </span>.terraform<span class="w"> </span>.terraform.lock.hcl<span class="w"> </span>state/

--- a/reference-architectures/backstage/backstage-quickstart/README.md
+++ b/reference-architectures/backstage/backstage-quickstart/README.md
@@ -373,7 +373,7 @@ permissions.
     xargs) && \
     cp backend.tf.local backend.tf && \
     terraform init -force-copy -lock=false -migrate-state && \
-    gsutil -m rm -rf gs://${TERRAFORM_BUCKET_NAME}/* && \
+    gcloud storage rm --recursive --continue-on-error gs://${TERRAFORM_BUCKET_NAME}/* && \
     terraform init && \
     terraform destroy -auto-approve  && \
     rm -rf .terraform .terraform.lock.hcl state/

--- a/reference-architectures/backstage/backstage-quickstart/README.md
+++ b/reference-architectures/backstage/backstage-quickstart/README.md
@@ -373,7 +373,8 @@ permissions.
     xargs) && \
     cp backend.tf.local backend.tf && \
     terraform init -force-copy -lock=false -migrate-state && \
-    gcloud storage rm --recursive --continue-on-error gs://${TERRAFORM_BUCKET_NAME}/* && \
+    gcloud storage rm --recursive --continue-on-error
+    gs://${TERRAFORM_BUCKET_NAME}/* && \
     terraform init && \
     terraform destroy -auto-approve  && \
     rm -rf .terraform .terraform.lock.hcl state/


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
